### PR TITLE
fix: Fix LoRA selector text truncation

### DIFF
--- a/src/components/playground/FormField.tsx
+++ b/src/components/playground/FormField.tsx
@@ -312,7 +312,7 @@ export function FormField({ field, value, onChange, disabled = false, error, mod
           )}
         </div>
       )}
-      <div className={cn("overflow-hidden", error && "[&_input]:border-destructive [&_textarea]:border-destructive")}>
+      <div className={cn(field.type !== 'loras' && "overflow-hidden", error && "[&_input]:border-destructive [&_textarea]:border-destructive")}>
         {renderInput()}
       </div>
       {error && (

--- a/src/components/playground/LoraSelector.tsx
+++ b/src/components/playground/LoraSelector.tsx
@@ -58,9 +58,9 @@ export function LoraSelector({
           <Label className="text-xs text-muted-foreground">Selected LoRAs ({value.length}/{maxItems})</Label>
           {value.map((lora, index) => (
             <div key={lora.path} className="space-y-2 p-3 bg-muted/50 rounded-lg">
-              <div className="flex items-center justify-between gap-2">
-                <span className="text-sm font-medium truncate flex-1" title={lora.path}>
-                  {lora.path.split('/').pop()}
+              <div className="flex items-start justify-between gap-2">
+                <span className="text-sm font-medium break-all flex-1" title={lora.path}>
+                  {lora.path}
                 </span>
                 <Button
                   type="button"


### PR DESCRIPTION
## Summary

- Fix LoRA path text being truncated and unreadable when using long URLs
- Remove `overflow-hidden` for loras field type in FormField to prevent content clipping  
- Display full LoRA path with word-wrap instead of truncated filename only
- Align delete button to top for multi-line text display

## Screenshots

### Before
<!-- Add before.png screenshot here -->
Long LoRA URLs are truncated and cannot be read fully.

### After  
<!-- Add after.png screenshot here -->
Full LoRA path is now visible with proper word-wrap.

## Test plan

- [ ] Open Playground with a LoRA-enabled model (e.g., wavespeed-ai/wan-2.2/i2v-480p-lora)
- [ ] Add a LoRA with a long URL path
- [ ] Verify the full path is displayed with word-wrap
- [ ] Verify multiple LoRAs can still be added

🤖 Generated with [Claude Code](https://claude.com/claude-code)