### PR TITLE
Fix Linux sandbox launch and SD library path

### DIFF
--- a/electron/lib/sdGenerator.ts
+++ b/electron/lib/sdGenerator.ts
@@ -154,10 +154,15 @@ export class SDGenerator {
     console.log('[SDGenerator] Spawning SD process:', binaryPath)
     console.log('[SDGenerator] Arguments:', JSON.stringify(args))
 
+    const binaryDir = dirname(binaryPath)
+    const ldLibraryPath = process.env.LD_LIBRARY_PATH
+      ? `${binaryDir}:${process.env.LD_LIBRARY_PATH}`
+      : binaryDir
+
     // Spawn child process
     const childProcess = spawn(binaryPath, args, {
       cwd: outputDir,
-      env: { ...process.env }
+      env: { ...process.env, LD_LIBRARY_PATH: ldLibraryPath }
     })
 
     // Track active process for cancellation

--- a/package.json
+++ b/package.json
@@ -166,12 +166,6 @@
     "linux": {
       "target": [
         {
-          "target": "AppImage",
-          "arch": [
-            "x64"
-          ]
-        },
-        {
           "target": "deb",
           "arch": [
             "x64"
@@ -179,10 +173,7 @@
         }
       ],
       "category": "Development",
-      "maintainer": "WaveSpeed <support@wavespeed.ai>",
-      "executableArgs": [
-        "--no-sandbox"
-      ]
+      "maintainer": "WaveSpeed <support@wavespeed.ai>"
     },
     "deb": {
       "afterInstall": "build/linux/after-install.sh"


### PR DESCRIPTION
### Motivation
- Prevent crashes on Ubuntu caused by Electron sandbox incompatibility by forcing `--no-sandbox` for installed launches. 
- Ensure the bundled Stable Diffusion shared library is discovered at runtime by setting `LD_LIBRARY_PATH`. 
- Avoid AppImage-related desktop launcher issues by handling launch behavior in the deb installer wrapper. 

### Description
- Replace post-install symlink with a wrapper script in `build/linux/after-install.sh` that execs the packaged binary with `--no-sandbox`, patches the `.desktop` `Exec=` line, installs multiple icon sizes, and refreshes the icon cache. 
- Remove the AppImage target and the `executableArgs` entry from the `linux` section of `package.json` so the deb installer/wrapper is used for launches. 
- Prepend the SD binary directory to `LD_LIBRARY_PATH` in `electron/lib/sdGenerator.ts` before calling `spawn` so bundled shared libraries (e.g. `libstable-diffusion.so`) are found. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695001f78b60832f841d65429126b21f)