### PR TITLE
Restrict deploy-to-server to tagged builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,3 +104,28 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-to-server:
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/v') && needs.release.result == 'success'
+    runs-on: namespace-profile-default
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Add SSH Private Key
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_PROD }}
+
+      - name: Deploy to Server
+        run: |
+          ssh -o StrictHostKeyChecking=no ubuntu@43.153.9.233 '
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" &&
+            cd /home/ubuntu/service/wavespeed-desktop &&
+            git reset --hard origin/main &&
+            git pull &&
+            npm install &&
+            npm run build
+          '

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -172,26 +172,3 @@ jobs:
           draft: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  deploy-to-server:
-    runs-on: namespace-profile-default
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Add SSH Private Key
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_PROD }}
-
-      - name: Deploy to Server
-        run: |
-          ssh -o StrictHostKeyChecking=no ubuntu@43.153.9.233 '
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" &&
-            cd /home/ubuntu/service/wavespeed-desktop && 
-            git reset --hard origin/main &&
-            git pull &&
-            npm install &&
-            npm run build
-          '


### PR DESCRIPTION
### Motivation
- Prevent automatic deployment from running on nightly builds to avoid deploying pre-release artifacts.
- Ensure production deploys only occur after a successful tagged release build.
- Keep nightly workflow focused on artifact generation and pre-release publication.

### Description
- Removed the `deploy-to-server` job from `.github/workflows/nightly.yml`.
- Added a `deploy-to-server` job to `.github/workflows/build.yml` after the `release` job and made it depend on `needs: release`.
- Gated the new job with the condition `if: startsWith(github.ref, 'refs/tags/v') && needs.release.result == 'success'` so it only runs on tagged builds after a successful release.
- Deployment step still performs the SSH deploy sequence (`ssh ... && npm install && npm run build`) to the production host.

### Testing
- No automated tests were run because this is a CI workflow configuration change only.
- Changes were validated locally by updating the workflow files `.github/workflows/build.yml` and `.github/workflows/nightly.yml` in the branch.
- Commit and PR creation steps completed successfully in the workspace.
- Recommend monitoring the next tagged release run to verify the deploy job triggers as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6950acd5f798832f9bdff4e49c0bef9a)