### PR TITLE
Restore AppImage build target for Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,12 @@
     "linux": {
       "target": [
         {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
           "target": "deb",
           "arch": [
             "x64"


### PR DESCRIPTION
Fix auto-update 404 error for Linux AppImage users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)