### PR TITLE
Fix formFields is not defined in runPrediction

### DIFF
--- a/src/stores/playgroundStore.ts
+++ b/src/stores/playgroundStore.ts
@@ -342,7 +342,7 @@ export const usePlaygroundStore = create<PlaygroundState>((set, get) => ({
     const activeTab = get().getActiveTab()
     if (!activeTab) return
 
-    const { selectedModel, formValues } = activeTab
+    const { selectedModel, formValues, formFields } = activeTab
     if (!selectedModel) {
       set(state => ({
         tabs: state.tabs.map(tab =>


### PR DESCRIPTION
The destructuring of activeTab in runPrediction was missing formFields, causing a ReferenceError when normalizePayloadArrays was called. This broke all I2V models and any model using array normalization.