### PR TITLE
fix: ensure integer schema fields are sent as integers to API

### DIFF
--- a/src/lib/schemaToForm.ts
+++ b/src/lib/schemaToForm.ts
@@ -15,6 +15,7 @@ export interface FormFieldConfig {
   maxFiles?: number
   placeholder?: string
   hidden?: boolean  // x-hidden fields are optional and hidden by default
+  schemaType?: string  // Original schema type (e.g. 'integer' vs 'number')
 }
 
 export function validateFormValues(fields: FormFieldConfig[], values: Record<string, unknown>): Record<string, string> {
@@ -256,6 +257,7 @@ function propertyToField(
       return {
         ...baseField,
         type: prop['x-ui-component'] === 'slider' ? 'slider' : 'number',
+        schemaType: prop.type,
         min: prop.minimum,
         max: prop.maximum,
         step: prop.step,

--- a/src/pages/SmartPlaygroundPage.tsx
+++ b/src/pages/SmartPlaygroundPage.tsx
@@ -359,15 +359,19 @@ export function SmartPlaygroundPage() {
       ? family.mapValues({ ...formValues }, resolvedVariantId)
       : formValues
     const variantFieldNames = getVariantFieldNames(resolvedModel)
+    const integerFields = new Set(visibleFields.filter(f => f.schemaType === 'integer').map(f => f.name))
     const cleanedValues: Record<string, unknown> = {}
     for (const [key, value] of Object.entries(mappedValues)) {
       if (!variantFieldNames.has(key)) continue
       if (value === undefined || value === null || value === '') continue
       if (Array.isArray(value) && value.length === 0) continue
-      cleanedValues[key] = value
+      // Ensure integer fields are sent as integers (API rejects non-integer values)
+      cleanedValues[key] = integerFields.has(key) && typeof value === 'number'
+        ? Math.round(value)
+        : value
     }
     return cleanedValues
-  }, [resolvedModel, formValues, family, resolvedVariantId])
+  }, [resolvedModel, formValues, family, resolvedVariantId, visibleFields])
 
   // Run prediction (single or batch)
   const handleRun = useCallback(async () => {

--- a/src/stores/playgroundStore.ts
+++ b/src/stores/playgroundStore.ts
@@ -384,9 +384,13 @@ export const usePlaygroundStore = create<PlaygroundState>((set, get) => ({
     try {
       // Clean up form values - remove empty strings and undefined
       const cleanedInput: Record<string, unknown> = {}
+      const integerFields = new Set(formFields.filter(f => f.schemaType === 'integer').map(f => f.name))
       for (const [key, value] of Object.entries(formValues)) {
         if (value !== '' && value !== undefined && value !== null) {
-          cleanedInput[key] = value
+          // Ensure integer fields are sent as integers (API rejects non-integer values)
+          cleanedInput[key] = integerFields.has(key) && typeof value === 'number'
+            ? Math.round(value)
+            : value
         }
       }
       const normalizedInput = normalizePayloadArrays(cleanedInput, formFields)
@@ -455,9 +459,12 @@ export const usePlaygroundStore = create<PlaygroundState>((set, get) => ({
 
     // Clean input values
     const cleanedBase: Record<string, unknown> = {}
+    const integerFields = new Set(formFields.filter(f => f.schemaType === 'integer').map(f => f.name))
     for (const [key, value] of Object.entries(formValues)) {
       if (value !== '' && value !== undefined && value !== null) {
-        cleanedBase[key] = value
+        cleanedBase[key] = integerFields.has(key) && typeof value === 'number'
+          ? Math.round(value)
+          : value
       }
     }
 


### PR DESCRIPTION
Models with integer fields like max_images (Seedream sequential, Nano Banana multi) would fail with "value must be an integer" because schemaToForm merged integer and number types, losing the original type info. Add schemaType to FormFieldConfig and apply Math.round() when building payloads.