### PR TITLE
feat(workflow): add collapsible (shrink) mode for nodes

### DIFF
--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1136,6 +1136,8 @@
     "hideRun": "إخفاء هذا التشغيل",
     "output": "الإخراج",
     "outputLowercase": "الإخراج",
+    "expandNode": "توسيع",
+    "collapseNode": "طي",
     "invalidUrl": "URL غير صالح",
     "removeLast": "إزالة האחר",
     "enterField": "أدخل {{field}}...",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1137,6 +1137,8 @@
     "hideRun": "Diesen Lauf ausblenden",
     "output": "Ausgabe",
     "outputLowercase": "Ausgabe",
+    "expandNode": "Erweitern",
+    "collapseNode": "Einklappen",
     "invalidUrl": "Ungültige URL",
     "removeLast": "Letztes entfernen",
     "enterField": "{{field}} eingeben...",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1196,6 +1196,8 @@
     "hideRun": "Hide this run",
     "output": "Output",
     "outputLowercase": "output",
+    "expandNode": "Expand",
+    "collapseNode": "Collapse",
     "invalidUrl": "Invalid URL",
     "removeLast": "Remove last",
     "enterField": "Enter {{field}}...",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1136,6 +1136,8 @@
     "hideRun": "Ocultar esta ejecución",
     "output": "Salida",
     "outputLowercase": "Salida",
+    "expandNode": "Expandir",
+    "collapseNode": "Contraer",
     "invalidUrl": "URL no válida",
     "removeLast": "Quitar último",
     "enterField": "Introducir {{field}}...",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1137,6 +1137,8 @@
     "hideRun": "Masquer cette exécution",
     "output": "Sortie",
     "outputLowercase": "Sortie",
+    "expandNode": "Développer",
+    "collapseNode": "Réduire",
     "invalidUrl": "URL invalide",
     "removeLast": "Supprimer le dernier",
     "enterField": "Entrer {{field}}...",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -1136,6 +1136,8 @@
     "hideRun": "इस रन को छिपाएं",
     "output": "आउटपुट",
     "outputLowercase": "आउटपुट",
+    "expandNode": "विस्तार करें",
+    "collapseNode": "संक्षिप्त करें",
     "invalidUrl": "अमान्य URL",
     "removeLast": "अंतिम हटाएं",
     "enterField": "{{field}} दर्ज करें...",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -1136,6 +1136,8 @@
     "hideRun": "Sembunyikan proses ini",
     "output": "Keluaran",
     "outputLowercase": "Keluaran",
+    "expandNode": "Perluas",
+    "collapseNode": "Ciutkan",
     "invalidUrl": "URL tidak valid",
     "removeLast": "Hapus terakhir",
     "enterField": "Masukkan {{field}}...",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1136,6 +1136,8 @@
     "hideRun": "Nascondi questa esecuzione",
     "output": "Output",
     "outputLowercase": "Output",
+    "expandNode": "Espandi",
+    "collapseNode": "Comprimi",
     "invalidUrl": "URL non valida",
     "removeLast": "Rimuovi ultimo",
     "enterField": "Inserisci {{field}}...",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1097,6 +1097,8 @@
     "pointsLabel": "分割ポイント",
     "output": "出力",
     "outputLowercase": "出力",
+    "expandNode": "展開",
+    "collapseNode": "折りたたむ",
     "invalidUrl": "無効な URL",
     "removeLast": "最後の項目を削除",
     "enterField": "{{field}} を入力...",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1137,6 +1137,8 @@
     "hideRun": "이 실행 숨기기",
     "output": "출력",
     "outputLowercase": "출력",
+    "expandNode": "펼치기",
+    "collapseNode": "접기",
     "invalidUrl": "잘못된 URL",
     "removeLast": "마지막 제거",
     "enterField": "{{field}} 입력...",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -1136,6 +1136,8 @@
     "hideRun": "Sembunyikan larian ini",
     "output": "Output",
     "outputLowercase": "Output",
+    "expandNode": "Kembang",
+    "collapseNode": "Kuncupkan",
     "invalidUrl": "URL tidak sah",
     "removeLast": "Buang yang terakhir",
     "enterField": "Masukkan {{field}}...",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1136,6 +1136,8 @@
     "hideRun": "Ocultar esta execução",
     "output": "Saída",
     "outputLowercase": "Saída",
+    "expandNode": "Expandir",
+    "collapseNode": "Recolher",
     "invalidUrl": "URL inválida",
     "removeLast": "Remover último",
     "enterField": "Introduza {{field}}...",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1136,6 +1136,8 @@
     "hideRun": "Скрыть это выполнение",
     "output": "Вывод",
     "outputLowercase": "Вывод",
+    "expandNode": "Развернуть",
+    "collapseNode": "Свернуть",
     "invalidUrl": "Недействительный URL",
     "removeLast": "Удалить последний",
     "enterField": "Введите {{field}}...",

--- a/src/i18n/locales/th.json
+++ b/src/i18n/locales/th.json
@@ -1136,6 +1136,8 @@
     "hideRun": "ซ่อนการดำเนินการนี้",
     "output": "ผลลัพธ์",
     "outputLowercase": "ผลลัพธ์",
+    "expandNode": "ขยาย",
+    "collapseNode": "ยุบ",
     "invalidUrl": "URL ไม่ถูกต้อง",
     "removeLast": "ลบรายการสุดท้าย",
     "enterField": "ใส่{{field}}...",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1136,6 +1136,8 @@
     "hideRun": "Bu çalıştırmayı gizle",
     "output": "Çıktı",
     "outputLowercase": "Çıktı",
+    "expandNode": "Genişlet",
+    "collapseNode": "Daralt",
     "invalidUrl": "Geçersiz URL",
     "removeLast": "Sonuncuyu kaldır",
     "enterField": "{{field}} girin...",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -1136,6 +1136,8 @@
     "hideRun": "Ẩn lần chạy này",
     "output": "Đầu ra",
     "outputLowercase": "Đầu ra",
+    "expandNode": "Mở rộng",
+    "collapseNode": "Thu gọn",
     "invalidUrl": "URL không hợp lệ",
     "removeLast": "Xóa mục cuối",
     "enterField": "Nhập {{field}}...",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1181,6 +1181,8 @@
     "hideRun": "隐藏本次运行",
     "output": "输出",
     "outputLowercase": "输出",
+    "expandNode": "展开",
+    "collapseNode": "收起",
     "invalidUrl": "无效 URL",
     "removeLast": "移除最后一项",
     "enterField": "输入 {{field}}...",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1094,6 +1094,8 @@
     "pointsLabel": "分割點",
     "output": "輸出",
     "outputLowercase": "輸出",
+    "expandNode": "展開",
+    "collapseNode": "收合",
     "invalidUrl": "無效 URL",
     "removeLast": "移除最後一項",
     "enterField": "輸入 {{field}}...",

--- a/src/workflow/components/canvas/custom-node/CustomNode.tsx
+++ b/src/workflow/components/canvas/custom-node/CustomNode.tsx
@@ -28,6 +28,7 @@ import type { NodeStatus } from "@/workflow/types/execution";
 import type { WaveSpeedModel } from "@/workflow/types/node-defs";
 import type { FormFieldConfig } from "@/lib/schemaToForm";
 
+import { ChevronDown, ChevronUp } from "lucide-react";
 import {
   type CustomNodeData,
   MIN_NODE_WIDTH,
@@ -75,6 +76,20 @@ function CustomNodeComponent({
   const [resizing, setResizing] = useState(false);
   const { getViewport, setNodes } = useReactFlow();
   const shortId = id.slice(0, 8);
+  const collapsed =
+    (data.params?.__nodeCollapsed as boolean | undefined) ?? false;
+  const setCollapsed = useCallback(
+    (value: boolean) =>
+      updateNodeParams(id, { ...data.params, __nodeCollapsed: value }),
+    [id, data.params, updateNodeParams],
+  );
+  const toggleCollapsed = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setCollapsed(!collapsed);
+    },
+    [collapsed, setCollapsed],
+  );
   const NodeIcon = getNodeIcon(data.nodeType);
   const nodeLabel =
     data.nodeType === "ai-task/run"
@@ -707,6 +722,18 @@ function CustomNodeComponent({
                     : "bg-[hsl(var(--muted-foreground))] opacity-30"
           }`}
           />
+          <button
+            type="button"
+            onClick={toggleCollapsed}
+            className="nodrag nopan flex-shrink-0 p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+            title={collapsed ? t("workflow.expandNode", "Expand") : t("workflow.collapseNode", "Collapse")}
+          >
+            {collapsed ? (
+              <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" />
+            ) : (
+              <ChevronUp className="w-3.5 h-3.5 text-muted-foreground" />
+            )}
+          </button>
           {NodeIcon && (
             <div className="rounded-md bg-primary/10 p-1 flex-shrink-0">
               <NodeIcon className="w-3.5 h-3.5 text-primary" />
@@ -719,7 +746,6 @@ function CustomNodeComponent({
             {shortId}
           </span>
         </div>
-
         {/* ── Running status bar ── */}
         {running && (
           <div className="px-3 py-1.5 bg-blue-500/5">
@@ -799,7 +825,7 @@ function CustomNodeComponent({
           </div>
         )}
 
-        {/* ── Body ───────────────────────────────────────────────────── */}
+        {/* ── Body (full when expanded; only connected rows when collapsed) ────────────── */}
         <CustomNodeBody
           id={id}
           data={data}
@@ -843,6 +869,7 @@ function CustomNodeComponent({
           inlinePreviewIs3D={inlinePreviewIs3D}
           resultsExpanded={resultsExpanded}
           setResultsExpanded={setResultsExpanded}
+          collapsed={collapsed}
         />
 
         {/* ── Resize handles — 4 edges + 4 corners ────────────────── */}

--- a/src/workflow/components/canvas/custom-node/CustomNodeBody.tsx
+++ b/src/workflow/components/canvas/custom-node/CustomNodeBody.tsx
@@ -104,6 +104,7 @@ export interface CustomNodeBodyProps {
   inlinePreviewIs3D: boolean;
   resultsExpanded: boolean;
   setResultsExpanded: Dispatch<SetStateAction<boolean>>;
+  collapsed?: boolean;
 }
 
 export function CustomNodeBody(props: CustomNodeBodyProps) {
@@ -150,11 +151,225 @@ export function CustomNodeBody(props: CustomNodeBodyProps) {
     inlinePreviewIs3D,
     resultsExpanded,
     setResultsExpanded,
+    collapsed = false,
   } = props;
   const { t } = useTranslation();
 
+  /* ── Collapsed: only connected rows in same order as expanded ── */
+  if (collapsed) {
+    return (
+      <div className="px-1">
+        {data.nodeType === "input/media-upload" &&
+          inputDefs.map((inp) => {
+            const hid = `input-${inp.key}`;
+            if (!connectedSet.has(hid)) return null;
+            return (
+              <Row key={inp.key}>
+                <div className="flex items-center justify-between gap-2 w-full">
+                  <span className="text-xs whitespace-nowrap flex-shrink-0 text-green-400 font-semibold">
+                    <HandleAnchor
+                      id={hid}
+                      type="target"
+                      connected
+                      media
+                    />
+                    {localizeInputLabel(inp.key, inp.label)}
+                  </span>
+                  <ConnectedInputControl
+                    nodeId={id}
+                    handleId={hid}
+                    edges={edges}
+                    nodes={useWorkflowStore.getState().nodes}
+                    onPreview={openPreview}
+                  />
+                </div>
+              </Row>
+            );
+          })}
+        {isAITask && (
+          <div className="nodrag px-3 mb-1" onClick={(e) => e.stopPropagation()}>
+            <ModelSelector
+              models={storeModels}
+              value={currentModelId || undefined}
+              onChange={(modelId) => {
+                const storeModel = getModelById(modelId);
+                if (!storeModel) return;
+                handleInlineSelectModel(convertDesktopModel(storeModel));
+              }}
+            />
+          </div>
+        )}
+        {isAITask &&
+          usePlaygroundForm &&
+          visibleFormFields.map((field) => {
+            const hid = `param-${field.name}`;
+            if (!connectedSet.has(hid)) return null;
+            const isMediaField =
+              field.type === "file" ||
+              field.type === "file-array" ||
+              /image|video|audio|mask/i.test(field.name);
+            return (
+              <Row key={field.name}>
+                <div className="flex flex-col gap-1 w-full">
+                  <div className="flex items-center">
+                    <span className="text-sm font-medium leading-none">
+                      <HandleAnchor
+                        id={hid}
+                        type="target"
+                        connected
+                        media={isMediaField}
+                      />
+                      {field.label || field.name}
+                      {field.required && (
+                        <span className="ml-0.5 text-destructive">*</span>
+                      )}
+                    </span>
+                  </div>
+                  {isMediaField ? (
+                    <ConnectedInputControl
+                      nodeId={id}
+                      handleId={hid}
+                      edges={edges}
+                      nodes={useWorkflowStore.getState().nodes}
+                      onPreview={openPreview}
+                    />
+                  ) : (
+                    <LinkedBadge
+                      nodeId={id}
+                      handleId={hid}
+                      edges={edges}
+                      nodes={useWorkflowStore.getState().nodes}
+                      onDisconnect={() => {
+                        const edge = edges.find(
+                          (e) => e.target === id && e.targetHandle === hid,
+                        );
+                        if (edge)
+                          useWorkflowStore.getState().removeEdge(edge.id);
+                      }}
+                    />
+                  )}
+                </div>
+              </Row>
+            );
+          })}
+        {isAITask &&
+          usePlaygroundForm &&
+          hiddenFormFields.map((field) => {
+            const hid = `param-${field.name}`;
+            if (!connectedSet.has(hid)) return null;
+            const isMediaField =
+              field.type === "file" ||
+              field.type === "file-array" ||
+              /image|video|audio|mask/i.test(field.name);
+            return (
+              <Row key={field.name}>
+                <div className="flex flex-col gap-1 w-full">
+                  <div className="flex items-center">
+                    <span className="text-sm font-medium leading-none">
+                      <HandleAnchor
+                        id={hid}
+                        type="target"
+                        connected
+                        media={isMediaField}
+                      />
+                      {field.label || field.name}
+                    </span>
+                  </div>
+                  {isMediaField ? (
+                    <ConnectedInputControl
+                      nodeId={id}
+                      handleId={hid}
+                      edges={edges}
+                      nodes={useWorkflowStore.getState().nodes}
+                      onPreview={openPreview}
+                    />
+                  ) : (
+                    <LinkedBadge
+                      nodeId={id}
+                      handleId={hid}
+                      edges={edges}
+                      nodes={useWorkflowStore.getState().nodes}
+                      onDisconnect={() => {
+                        const edge = edges.find(
+                          (e) => e.target === id && e.targetHandle === hid,
+                        );
+                        if (edge)
+                          useWorkflowStore.getState().removeEdge(edge.id);
+                      }}
+                    />
+                  )}
+                </div>
+              </Row>
+            );
+          })}
+        {data.nodeType !== "input/media-upload" &&
+          data.nodeType !== "input/text-input" &&
+          inputDefs.map((inp) => {
+            const hid = `input-${inp.key}`;
+            if (!connectedSet.has(hid)) return null;
+            return (
+              <Row key={inp.key}>
+                <div className="flex items-center justify-between gap-2 w-full">
+                  <span className="text-xs whitespace-nowrap flex-shrink-0 text-green-400 font-semibold">
+                    <HandleAnchor
+                      id={hid}
+                      type="target"
+                      connected
+                      media
+                    />
+                    {localizeInputLabel(inp.key, inp.label)}
+                    {inp.required && <span className="text-red-400"> *</span>}
+                  </span>
+                  <ConnectedInputControl
+                    nodeId={id}
+                    handleId={hid}
+                    edges={edges}
+                    nodes={useWorkflowStore.getState().nodes}
+                    onPreview={openPreview}
+                  />
+                </div>
+              </Row>
+            );
+          })}
+        {data.nodeType !== "input/media-upload" &&
+          data.nodeType !== "input/text-input" &&
+          paramDefs.map((p) => {
+            const hid = `param-${p.key}`;
+            const canConnect =
+              p.connectable !== false && p.dataType !== undefined;
+            if (!canConnect || !connectedSet.has(hid)) return null;
+            return (
+              <Row key={p.key}>
+                <div className="flex flex-col gap-1 w-full">
+                  <div className="flex items-center">
+                    <span className="text-sm font-medium leading-none">
+                      <HandleAnchor id={hid} type="target" connected />
+                      {localizeParamLabel(p.key, p.label)}
+                    </span>
+                  </div>
+                  <LinkedBadge
+                    nodeId={id}
+                    handleId={hid}
+                    edges={edges}
+                    nodes={useWorkflowStore.getState().nodes}
+                    onDisconnect={() => {
+                      const edge = edges.find(
+                        (e) => e.target === id && e.targetHandle === hid,
+                      );
+                      if (edge)
+                        useWorkflowStore.getState().removeEdge(edge.id);
+                    }}
+                  />
+                </div>
+              </Row>
+            );
+          })}
+      </div>
+    );
+  }
+
   return (
-    <div className="px-1 py-2 space-y-px">
+    <div className="px-1 space-y-px">
       {/* Free-tool ML model download hint */}
       {status === "idle" &&
         resultGroups.length === 0 &&


### PR DESCRIPTION
- Add collapsed state for workflow nodes
- Hide node body content when collapsed
- Keep node header/title visible
- Preserve input/output connections while collapsed
- Allow toggling between expanded and collapsed states

Improves readability and navigation in large workflows.

Screenshots attached:
- Before: full node view (expanded)
<img width="1237" height="949" alt="{8759CE66-D147-45D3-AFCC-3088E4E6CB46}" src="https://github.com/user-attachments/assets/d6a8c26c-c64d-48c0-9cac-dff396306462" />

- After: compact (collapsed) node view, with and without connections
<img width="1605" height="819" alt="{E489E575-E099-45AF-AC90-B786575096D4}" src="https://github.com/user-attachments/assets/3249ed8c-d383-4694-9612-ad4c6db73882" />
